### PR TITLE
Remove worker

### DIFF
--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.44.0
+version: 0.44.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.24.2

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if $.Values.server.enabled }}
-{{- range $service := (list "frontend" "history" "matching" "worker") }}
+{{- range $service := (list "frontend" "history" "matching") }}
 {{ $serviceValues := index $.Values.server $service }}
 apiVersion: apps/v1
 kind: Deployment
@@ -117,9 +117,9 @@ spec:
               protocol: TCP
           {{- if ne $service "worker" }}
           livenessProbe:
-             initialDelaySeconds: 150
-             tcpSocket:
-               port: rpc
+            initialDelaySeconds: 150
+            tcpSocket:
+              port: rpc
           {{- end }}
           volumeMounts:
             - name: config

--- a/charts/temporal/templates/server-pdb.yaml
+++ b/charts/temporal/templates/server-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if $.Values.server.enabled }}
-{{- range $service := (list "frontend" "history" "matching" "worker") }}
+{{- range $service := (list "frontend" "history" "matching") }}
 {{- $serviceValues := index $.Values.server $service -}}
 {{- if and (gt ($serviceValues.replicaCount | int) 1) ($serviceValues.podDisruptionBudget) }}
 apiVersion: policy/v1

--- a/charts/temporal/templates/server-service-monitor.yaml
+++ b/charts/temporal/templates/server-service-monitor.yaml
@@ -1,5 +1,5 @@
 {{- if $.Values.server.enabled }}
-{{- range $service := (list "frontend" "matching" "history" "worker") }}
+{{- range $service := (list "frontend" "matching" "history") }}
 {{- $serviceValues := index $.Values.server $service -}}
 {{- if (default $.Values.server.metrics.serviceMonitor.enabled $serviceValues.metrics.serviceMonitor.enabled) }}
 apiVersion: monitoring.coreos.com/v1

--- a/charts/temporal/templates/server-service.yaml
+++ b/charts/temporal/templates/server-service.yaml
@@ -35,7 +35,7 @@ spec:
     app.kubernetes.io/component: frontend
 
 ---
-{{- range $service := (list "frontend" "matching" "history" "worker") }}
+{{- range $service := (list "frontend" "matching" "history") }}
 {{ $serviceValues := index $.Values.server $service }}
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
- remove all the resources for `worker`

Workers will be managed outside of the helm chart. No reason to keep the default worker around.