### PR TITLE
Add option for hostAliases

### DIFF
--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.44.2
+version: 0.44.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.24.2

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -51,6 +51,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
+      {{- with $serviceValues.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
       initContainers:
         {{- if $.Values.cassandra.enabled }}
@@ -117,9 +121,9 @@ spec:
               protocol: TCP
           {{- if ne $service "worker" }}
           livenessProbe:
-             initialDelaySeconds: 150
-             tcpSocket:
-               port: rpc
+            initialDelaySeconds: 150
+            tcpSocket:
+              port: rpc
           {{- end }}
           volumeMounts:
             - name: config

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -292,6 +292,7 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
+    hostAliases: {}
 admintools:
   enabled: true
   image:


### PR DESCRIPTION
hostAliases is needed to divert worker through an auth proxy in order to connect with frontend when an authorizer is enabled. 