### PR TITLE
Add host aliases option

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @temporalio/devex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.50.0
+version: 0.50.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.25.1

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -104,9 +104,9 @@ spec:
               protocol: TCP
           {{- if ne $service "worker" }}
           livenessProbe:
-             initialDelaySeconds: 150
-             tcpSocket:
-               port: rpc
+            initialDelaySeconds: 150
+            tcpSocket:
+              port: rpc
           {{- end }}
           volumeMounts:
             - name: config

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -159,6 +159,10 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with $serviceValues.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -242,6 +242,7 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
+    hostAliases: {}
   history:
     service:
       # type: ClusterIP
@@ -266,6 +267,7 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
+    hostAliases: {}
   matching:
     service:
       # type: ClusterIP
@@ -290,6 +292,7 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
+    hostAliases: {}
   worker:
     service:
       # type: ClusterIP
@@ -314,6 +317,7 @@ server:
     containerSecurityContext: {}
     topologySpreadConstraints: []
     podDisruptionBudget: {}
+    hostAliases: {}
 admintools:
   enabled: true
   image:


### PR DESCRIPTION
Allow setting pod's `hostAliases` from values file to override DNS entries. This is necessary to make the builtin temporal worker use a proxy to frontend which performs authN on worker's behalf.