### PR TITLE
Duplicate configmap for worker with proxy option

### DIFF
--- a/charts/temporal/Chart.yaml
+++ b/charts/temporal/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.48.2
+version: 0.48.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.25.1

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.server.enabled -}}
 {{- $server := .Values.server -}}
 {{- $elasticsearch := .Values.elasticsearch -}}
+{{- range $service := (list "server" "worker") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -174,9 +175,10 @@ data:
     {{- end }}
 
     publicClient:
-      hostPort: "{{ include "temporal.componentname" (list $ "frontend") }}:{{ $server.frontend.service.port }}"
+      hostPort: "{{ if (and (eq $service "worker") (hasKey $server.worker proxyHost)) }}{{ $server.worker.proxyHost }}{{ else }}{{ include "temporal.componentname" (list $ "frontend") }}:{{ $server.frontend.service.port }}{{ end }}"
 
     dynamicConfigClient:
       filepath: "/etc/temporal/dynamic_config/dynamic_config.yaml"
       pollInterval: "10s"
+{{- end }}
 {{- end }}

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ include "temporal.fullname" $ }}-config"
+  name: "{{ include "temporal.fullname" $ }}-config{{ if eq $service "worker" }}-worker{{ end }}"
   labels:
     {{- include "temporal.resourceLabels" (list $ "" "") | nindent 4 }}
 data:

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -175,7 +175,7 @@ data:
     {{- end }}
 
     publicClient:
-      hostPort: "{{ if (and (eq $service "worker") (hasKey $server.worker proxyHost)) }}{{ default $server.worker.proxyHost "" }}{{ else }}{{ include "temporal.componentname" (list $ "frontend") }}:{{ $server.frontend.service.port }}{{ end }}"
+      hostPort: "{{ if (and (eq $service "worker") (hasKey $server.worker "proxyHost")) }}{{ $server.worker.proxyHost }}{{ else }}{{ include "temporal.componentname" (list $ "frontend") }}:{{ $server.frontend.service.port }}{{ end }}"
 
     dynamicConfigClient:
       filepath: "/etc/temporal/dynamic_config/dynamic_config.yaml"

--- a/charts/temporal/templates/server-configmap.yaml
+++ b/charts/temporal/templates/server-configmap.yaml
@@ -175,7 +175,7 @@ data:
     {{- end }}
 
     publicClient:
-      hostPort: "{{ if (and (eq $service "worker") (hasKey $server.worker proxyHost)) }}{{ $server.worker.proxyHost }}{{ else }}{{ include "temporal.componentname" (list $ "frontend") }}:{{ $server.frontend.service.port }}{{ end }}"
+      hostPort: "{{ if (and (eq $service "worker") (hasKey $server.worker proxyHost)) }}{{ default $server.worker.proxyHost "" }}{{ else }}{{ include "temporal.componentname" (list $ "frontend") }}:{{ $server.frontend.service.port }}{{ end }}"
 
     dynamicConfigClient:
       filepath: "/etc/temporal/dynamic_config/dynamic_config.yaml"

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -104,9 +104,9 @@ spec:
               protocol: TCP
           {{- if ne $service "worker" }}
           livenessProbe:
-             initialDelaySeconds: 150
-             tcpSocket:
-               port: rpc
+            initialDelaySeconds: 150
+            tcpSocket:
+              port: rpc
           {{- end }}
           volumeMounts:
             - name: config

--- a/charts/temporal/templates/server-deployment.yaml
+++ b/charts/temporal/templates/server-deployment.yaml
@@ -133,7 +133,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: "{{ include "temporal.fullname" $ }}-config"
+            name: "{{ include "temporal.fullname" $ }}-config{{ if eq $service "worker" }}-worker{{ end }}"
         - name: dynamic-config
           configMap:
             name: "{{ include "temporal.fullname" $ }}-dynamic-config"

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -307,6 +307,7 @@ server:
     topologySpreadConstraints: []
     podDisruptionBudget: {}
     hostAliases: []
+    # proxyHost: "proxy-service:7233"
 admintools:
   enabled: true
   image:


### PR DESCRIPTION
- clone the configmap containing `config_template.yaml` so we can have different config for the worker
- add value to override `publicClient.hostPort` with a proxy host for frontend

The proy host will then perform authorizer step on the worker's behalf